### PR TITLE
remove extra volume mount

### DIFF
--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -8,7 +8,6 @@ services:
       - ./webapp/config/.prod.env
     volumes:
       - /etc/letsencrypt:/etc/letsencrypt:ro # Mount SSL certificates
-      - ./webapp/config/nginx.conf:/etc/nginx/conf.d/default.conf # Custom NGINX config
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.5.1


### PR DESCRIPTION
nginx.conf is stored inside of the container so there is no need to mount it (this is currently breaking CI/CD which is why I'm making a request just for this).