### PR TITLE
Sidebar fixes

### DIFF
--- a/db/elasticsearch_wrapper_api.py
+++ b/db/elasticsearch_wrapper_api.py
@@ -142,11 +142,11 @@ def getSamples():
 
     if not es or not connected:
         print("❌ Elasticsearch is not connected.")
-        return None
+        return jsonify({"error": "Elasticsearch is not connected"}), 500
 
     if not es.indices.exists(index="wikipedia"):
         print(f"❌ Index 'wikipedia' does not exist")
-        return None
+        return jsonify({"error": "Index 'wikipedia' does not exist"}), 500
 
     try:
         seed = int(datetime.now().strftime("%H%M%S"))  # Use current time as seed

--- a/webapp/src/App.css
+++ b/webapp/src/App.css
@@ -15,13 +15,15 @@ html, body {
 
 .sidebar {
   width: 210px; 
+  height: 100vh;
   background-color: #b3cde0;
   padding: 1rem;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   flex-shrink: 0;
-  border-right: 2px solid #6497b1
+  border-right: 2px solid #6497b1;
+  position: fixed; 
 }
 
 .stored-responses {
@@ -63,6 +65,7 @@ html, body {
 
 .new-theory-button {
   width: 100%;
+  margin-bottom: 1.5rem;
 }
 
 .disabled-button {
@@ -107,11 +110,11 @@ html, body {
 }
 
 .disabled-button {
-    background-color: #9ca3af;
-    color: #4b5563;
-    cursor: not-allowed;
-    border: 2px solid #6b7280;
-    opacity: 0.6; 
+  background-color: #9ca3af;
+  color: #4b5563;
+  cursor: not-allowed;
+  border: 2px solid #6b7280;
+  opacity: 0.6; 
 }
 .response-box {
   border: 1px solid #d1d5db;

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -146,6 +146,7 @@ function App() {
                   if (window.confirm('Are you sure you want to clear the response history? This action cannot be undone.')) {
                     clearHistory();
                   }
+                  startNewTheory();
                 }}
                 title="Clear History"
                 style={{ background: 'none', border: 'none', cursor: 'pointer' }}
@@ -174,7 +175,7 @@ function App() {
 
         <img className="main-logo" src="favicon.png" />
 
-      <h1 className="title">Conspiragen</h1>
+        <h1 className="title">Conspiragen</h1>
       
         {!showResponse ? (
           <div>


### PR DESCRIPTION
Fix for history sidebar not reaching bottom of page with irregular window sizes.

After clearing history, it now goes to the screen for entering topics.

Added a couple error messages for fetching samples.